### PR TITLE
Relax restrictions against patient data processing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "3.5.1"
+gem 'jekyll', '>=3.5.1', '<3.7'
 
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 #gem "minima", "~> 2.0"
@@ -19,7 +19,7 @@ gem "jekyll", "3.5.1"
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do
-   gem "jekyll-feed", "~> 0.6"
+   gem 'jekyll-feed', '>=0.10'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,16 +28,16 @@ GEM
       rainbow (~> 3.0)
       typhoeus (~> 1.3)
       yell (~> 2.0)
-    jekyll (3.5.1)
+    jekyll (3.6.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
-      kramdown (~> 1.3)
+      kramdown (~> 1.14)
       liquid (~> 4.0)
       mercenary (~> 0.3.3)
       pathutil (~> 0.9)
-      rouge (~> 1.7)
+      rouge (>= 1.7, < 3)
       safe_yaml (~> 1.0)
     jekyll-compose (0.9.0)
       jekyll (~> 3.0)
@@ -78,7 +78,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.6)
-    rouge (1.11.1)
+    rouge (2.2.1)
     safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -94,9 +94,9 @@ PLATFORMS
 
 DEPENDENCIES
   html-proofer
-  jekyll (= 3.5.1)
+  jekyll (>= 3.5.1, < 3.7)
   jekyll-compose
-  jekyll-feed (~> 0.6)
+  jekyll-feed (>= 0.10)
   jekyll-git_metadata
   jekyll-scholar
   tzinfo-data

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # GDPR Compliance Documentation
+
+
+# Local testing
+To install an environment to locally inspect the compiled output, you can do the following.
+
+1. Create a conda environment and activate it:
+```
+conda create -n gdpr rb-bundler gxx_linux-64
+conda activate gdpr
+```
+
+2. Install the dependencies via bundler:
+```
+bundle install
+```
+
+3. Use the makefile to compile the markup files and let Jekyll serve a local instance:
+```
+make
+```
+
+

--- a/_data/people.yml
+++ b/_data/people.yml
@@ -7,6 +7,15 @@ SJ:
 BG:
   name: Bjoern Gruening
   affil: University of Freiburg, Freiburg, Germany
+SS:
+  name: Sanjay Srikakulam
+  affil: University of Freiburg, Freiburg, Germany
+MK:
+  name: Mira Kuntz
+  affil: University of Freiburg, Freiburg, Germany
+JD:
+  name: Jose Dominguez
+  affil: University of Freiburg, Freiburg, Germany
 MM:
   name: Manuel Messner
   affil: University of Freiburg, Freiburg, Germany

--- a/_data/pii.yml
+++ b/_data/pii.yml
@@ -26,6 +26,9 @@ data:
         - BG
         - SJ
         - HR
+        - SS
+        - MK
+        - JD
       disposal: Upon Request
       consent: true
       over_13: true
@@ -41,6 +44,9 @@ data:
         - BG
         - SJ
         - HR
+        - SS
+        - MK
+        - JD
       disposal: After 24 hours
       consent: false
       over_13: true
@@ -62,6 +68,9 @@ data:
         - BG
         - SJ
         - HR
+        - SS
+        - MK
+        - JD
       disposal: Never
       consent: false
       over_13: true
@@ -75,11 +84,14 @@ data:
       handling: |
         Stored permanently until you request deletion. You and the Galaxy
         administrators have access to this data. The Galaxy administrators
-        will not access your data except in order to resolve bugs with you.
+        will not access your data except in order to resolve bugs together with you.
       access:
         - BG
         - SJ
         - HR
+        - SS
+        - MK
+        - JD
       disposal: Never / On Request
       consent: true
       over_13: true

--- a/dpa/index.md
+++ b/dpa/index.md
@@ -3,7 +3,7 @@ layout: default
 title: Data Processing Activity (DPA) Register
 ---
 
-This table inspired by the [EC's Factsheet](https://ec.europa.eu/commission/sites/beta-political/files/data-protection-factsheet-business-7-steps_en.pdf)
+This table inspired by the [EC's Factsheet](https://edps.europa.eu/system/files/2021-12/20-12-01_data_protection_in_action_factsheet_en.pdf)
 
 {% include contact.html %}
 

--- a/gdpr-rights.md
+++ b/gdpr-rights.md
@@ -8,21 +8,21 @@ And how to exercise them in the context of the Galaxy Service provided by the Ga
 
 ## Right to be Informed
 
-We have published all of the documentation regarding the GDPR compliance at https://github.com/usegalaxy-eu/gdpr
+We have published all of the documentation regarding the GDPR compliance at [https://github.com/usegalaxy-eu/gdpr](https://github.com/usegalaxy-eu/gdpr).
 We will inform you of any and all processing activities and their affect on your personal information.
 
 ## Right to Access to Personal Information
 
-The only personal information we store that is associated with you, you can see on https://usegalaxy.eu/user/information
-We have logs containing IP addresses but these logs are destroyed after 24 hours and are not associated with a single user account.
+The only personal information we store that is associated with you, you can see on [https://usegalaxy.eu/user/information](https://usegalaxy.eu/user/information).
+We have logs containing IP addresses, but these logs are destroyed after 24 hours and are not associated with a single user account.
 
 ## Right to Rectification of Personal Information
 
-You can do this on https://usegalaxy.eu/user/information
+You can do this on [https://usegalaxy.eu/user/information](https://usegalaxy.eu/user/information)
 
-## Right to be Erasure
+## Right to Erasure
 
-We can manually delete your account upon request. In the future this will be something you can do yourself when we can [implement the feature upstream](https://github.com/galaxyproject/galaxy/issues/6081).
+We can manually delete your account upon your request. You can also initiate this yourself by completing the steps at User > User Preferences > Delete Account after logging in to your account.
 
 ## Right to Restrict Processing
 
@@ -35,7 +35,7 @@ The upstream software Galaxy currently does not support this workflow, but does 
 ## Right to Object
 
 All of the processing activities we currently do are required to use the service. We do not transmit any PII to third parties.
-If we do processing activities in the future that do affect PII, we will inform you and permit you to opt-out.
+If we do processing activities in the future that do affect PII, we will inform you in advance and permit you to opt-out.
 
 ## Right to Not be Subject to Automated Decision-making Including Profiling
 

--- a/lia/grt.md
+++ b/lia/grt.md
@@ -12,13 +12,13 @@ title: Galactic Radio Telescope (GRT) Legitimate Interest Assessment
 - The data is made available, free of charge, for anyone to analyse and draw conclusions about tool runtimes and cpu/memory usage based on input parameters.
 - The benefit to optimising resource consumption is significant.
 - If we could not go ahead we will continue to poorly schedule resources and not be able to freely support all of our users.
-- Our usage is ethical and lawful
+- Our usage is ethical and lawful.
 
 ## Necessity Test
 
-- The processing of the data is necessary to achieve the goals of the GRT project
-- This is the only way to go about it
-- We only obtain and send the minimum amount of data required to process the analysis
+- The processing of the data is necessary to achieve the goals of the GRT project.
+- This is the only way to go about it.
+- We only obtain and send the minimum amount of data required to process the analysis.
 
 ## Balancing Test
 

--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -4,36 +4,24 @@ published_effective: true
 title: Privacy Policy
 ---
 
-## Definitions
-
-European Galaxy Sites or "the Galaxy Service": any one of the Galaxy sites provided to you by the Freiburg Galaxy Team and the European Galaxy Project, including but not limited to:
-
-- https://usegalaxy.eu
-- https://hicexplorer.usegalaxy.eu
-- https://metagenomics.usegalaxy.eu
-- https://galaxy.uni-freiburg.de
-
-UseGalaxy Site
-
-- https://usegalaxy-eu.github.io
 
 ## Introduction
 
-The Galaxy Freiburg Team is aware the protection of your privacy is important when using our services European Galaxy Sites or UseGalaxy Site. We provide this statement to explain our information practices and the choices you can make about the way your information is collected and used. The amount and type of information received by us depends on how you use our website.
+The Galaxy Freiburg Team is aware that the protection of your privacy is important when using our services European Galaxy Sites or UseGalaxy Site. We provide this statement to explain our information practices and the choices you can make about the way your information is collected and used. The amount and type of information received by us depends on how you use our website.
 
 ## Information collected and use of information
 
-During normal usage of our services we do not collect information that will personally identify you. Our webservers only store information such as the Referrer (where you came to us from), pages that you access, and dates of your visit. We may use this information in anonymised aggregates in order to generate usage statistics and to improve the usefulness of our services. All of this data is discarded after 24 hours.
+During normal usage of our services we do not auto-collect information that will personally identify you. Our webservers only store information such as the Referrer (where you came to us from), pages that you access, and dates of your visit. We may use this information in anonymised aggregates in order to generate usage statistics and to improve the usefulness of our services. All of this data is discarded after 24 hours.
 
 Beyond this, we will only store personal information which you provide to us voluntarily (e.g. datasets uploaded to Galaxy, histories you create, etc.), or as part of a support request.
 
 The information required to register with the European Galaxy Sites and all uploaded data is solely used to offer the services provided by the Galaxy Freiburg Team. Username and email address are mandatory for registering with this service. This information is required to guarantee the legitimate use of the service and to prevent duplicate registrations abusing our quota system.
 
-For the European Galaxy Sites you can see all of the information we have stored related to your person and you have the right to correct this information at any time. For the Galaxy service you may do this by going to https://usegalaxy.eu, clicking on "User" → "Preferences" → "Manage Information". You also have the right to retract your consent to use personal identifiable information at any time with effect for the future. An email to the address stated below is sufficient. We never use or share the personally identifiable information provided to us in ways unrelated to the ones described above.
+For the European Galaxy Sites you can see all of the information we have stored related to your person and you have the right to correct this information at any time. For the Galaxy service you may do this by going to [https://usegalaxy.eu](https://usegalaxy.eu), clicking on "User" → "Preferences" → "Manage Information". You also have the right to retract your consent to use personal identifiable information at any time with effect for the future. An email to the address stated below is sufficient. We never use or share the personally identifiable information provided to us in ways unrelated to the ones described above.
 
 ## Cookies
 
-A cookie is a unique identifier given to a web browser by a web server. Each time the browser requests a page from the server, this identifier is sent back. The Galaxy service provided uses cookies to identify users/computers in order to maintain user sessions (e.g. to provide/maintain analysis results while you browse the website). Usage of cookies is in no way linked to any personally identifiable information about individual users. The information is also not shared with any third party. Unless you specifically tell us, we will never know who you are, even if we do assign a cookie to your computer. Most browsers are set to automatically accept cookies. If you prefer not to receive cookies, you may set your browser to warn you before accepting cookies or you may also refuse all cookies by turning them off in your browser. However, please be aware that in case of not accepting cookies, the functionality of our website is limited.
+A cookie is a unique identifier given to a web browser by a web server. Each time the browser requests a page from the server, this identifier is sent back to the server. The provided Galaxy service uses cookies to identify users/computers in order to maintain user sessions (e.g. to provide/maintain analysis results while you browse the website). Usage of cookies is in no way linked to any personally identifiable information about individual users. The information is also not shared with any third party. Unless you specifically tell us, we will never know who you are, even if we do assign a cookie to your computer. Most browsers are set to automatically accept cookies. If you prefer not to receive cookies, you may set your browser to warn you before accepting cookies or you may also refuse all cookies by turning them off in your browser. However, please be aware that in case your browser does not accept cookies, the functionality of our website might be limited.
 
 ## Links to Other Websites
 

--- a/scope.md
+++ b/scope.md
@@ -1,0 +1,19 @@
+---
+layout: history
+published_effective: true
+title: Definitions / scope
+---
+
+The terms and policies mentioned on this website govern the interactions between you, the End User, and us and our services.
+
+European Galaxy Sites or "the Galaxy Service", i.e. the Services, refer to any one of the Galaxy sites provided to you by the Freiburg Galaxy Team and the European Galaxy Project, including but not limited to:
+
+- [https://usegalaxy.eu](https://usegalaxy.eu)
+- [https://hicexplorer.usegalaxy.eu](https://hicexplorer.usegalaxy.eu)
+- [https://live.usegalaxy.eu](https://live.usegalaxy.eu)
+- [https://metagenomics.usegalaxy.eu](https://metagenomics.usegalaxy.eu)
+- [https://microgalaxy.usegalaxy.eu](https://microgalaxy.usegalaxy.eu)
+
+UseGalaxy Site
+
+- [https://usegalaxy-eu.github.io](https://usegalaxy-eu.github.io)

--- a/tos.md
+++ b/tos.md
@@ -4,23 +4,11 @@ published_effective: true
 title: Terms of Service
 ---
 
-## Definitions
 
-European Galaxy Sites or "the Galaxy Service": any one of the Galaxy sites provided to you by the Freiburg Galaxy Team and the European Galaxy Project, including but not limited to:
+## Use of Service
 
-- https://usegalaxy.eu
-- https://hicexplorer.usegalaxy.eu
-- https://metagenomics.usegalaxy.eu
-- https://galaxy.uni-freiburg.de
-
-UseGalaxy Site
-
-- https://usegalaxy-eu.github.io
-
-## Use of Service.
-
-The European Galaxy Sites and UseGalaxy Site are a free, public, Internet
-accessible resource (the "Service"). Data transfer is encrypted unless you
+The European Galaxy Sites and UseGalaxy Site are a free, public, Internet-accessible
+resource (the "Service"). Data transfer is encrypted unless you
 choose to use unencrypted FTP access. Data storage is not encrypted. If there
 are restrictions on the way your research data can be stored and used, please
 consult your local institutional review board or the project principal
@@ -32,22 +20,28 @@ deemed necessary by the operators of the Service.
 
 You acknowledge that you are responsible for compliance of all of your data
 processing activities carried out on the Galaxy Service with applicable laws
-and regulations of the Federal Republic of Germany, the European Union as well
+and regulations of the Federal Republic of Germany, the European Union, as well
 as any laws or regulations of other legislations or any other restrictions that
 might be applicable due to the provenance, intended use, legal ownership of or
 any licensing or other legal restrictions imposed on the data being processed.
 
-You are strictly prohibited from making use of the Galaxy Service for the
-storage or processing of any Personal Data or Sensitive Personal Data as
-defined by the European Union's General Data Protection Regulation (GDPR),
-including but not limited to potentially personally identifying medical data.
+Usegalaxy.eu is hosted out of an ISO 27001 certified data center operated by the
+[University of Freiburg IT Services](https://www.rz.uni-freiburg.de/en?set_language=en)
+and does its due diligence to ensure information security and data protection.
+However, this does not consitute a warranty for fitness for any particular purpose.
+You, the end user, bear the full responsibility for the implications of using our
+services. You are strictly prohibited from making use of the Galaxy Service for
+running non-scientific cryptography applications, storing and/or processing
+any data obtained from illegitimate sources, or any other activities that are
+categorized as a (cyber) crime with respect to the laws of Germany or EU.
+
 
 ## Accounts and Service Limitations
 
 You may choose to register an account with the Service. Your registration data
 is primarily used so you may persistently store data on the Service and use
 advanced Galaxy features such as sharing and workflows. The operators of the
-Service will not provide your registration data to any third party unless
+Service will not provide your registration data to any third party, unless
 required to do so by law. Your access to the Service is provided under the
 condition that you abide by any published quotas on data storage, job
 submissions, or any other limitations placed on the public Service. Attempts to


### PR DESCRIPTION
In the current setting, the ToS forbids usage of usegalaxy.eu for medical data processing. I propose relaxing this constraint so that collaborative with clinical departments is possible.

I also did some minor modifications regarding things that changed since 2018 (dead links, implemented functionalities etc.).

In pii.yml, I added our new admins. Do we still keep HR and BB in that document?

